### PR TITLE
Add necessary scp flag for OpenSSH 8.8 onward.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,12 +14,20 @@ if [ -z "$1" ]; then
 fi
 WYZECAMV3_HOST=$1
 
+OPENSSH_VERSION=$(ssh -V 2>&1)
+TARGET_VERSION="OpenSSH_8.8"
+SCP_ARGS=""
+# OpenSSH 8.8 onward uses SFTP protocol by default, which is unsupported on wz_mini_hacks
+if printf '%s\n' "$TARGET_VERSION" "$OPENSSH_VERSION" | sort -V | head -n1 | grep -q "$TARGET_VERSION"; then
+  SCP_ARGS="-O"
+fi
+
 echo "Uploading MQTT client to camera at ${WYZECAMV3_HOST}..."
 ssh root@${WYZECAMV3_HOST} 'mkdir -p /media/mmc/mosquitto/bin; mkdir -p /media/mmc/mosquitto/lib; mkdir -p /media/mmc/mosquitto/installer'
-scp ./installer/* root@${WYZECAMV3_HOST}:/media/mmc/mosquitto/installer
-scp ./bin/* root@${WYZECAMV3_HOST}:/media/mmc/mosquitto/bin
-scp ./lib/* root@${WYZECAMV3_HOST}:/media/mmc/mosquitto/lib
-scp mosquitto.conf root@${WYZECAMV3_HOST}:/media/mmc/mosquitto
+scp ${SCP_ARGS} ./installer/* root@${WYZECAMV3_HOST}:/media/mmc/mosquitto/installer
+scp ${SCP_ARGS} ./bin/* root@${WYZECAMV3_HOST}:/media/mmc/mosquitto/bin
+scp ${SCP_ARGS} ./lib/* root@${WYZECAMV3_HOST}:/media/mmc/mosquitto/lib
+scp ${SCP_ARGS} mosquitto.conf root@${WYZECAMV3_HOST}:/media/mmc/mosquitto
 
 echo "Installing MQTT client on camera..."
 ssh root@${WYZECAMV3_HOST} '/media/mmc/mosquitto/installer/setup.sh'


### PR DESCRIPTION
Fixes:
#7
#4 

According to the OpenSSH release notes, full support for the SFTP protocol was added in 8.8, and it was made the default in 9.0. However, the "-O" flag is referenced as far back as 8.6: https://www.openssh.com/releasenotes.html

Looking at the man pages for Ubuntu and OpenBSD:
* Ubuntu says "Since OpenSSH 8.8, scp has use the SFTP protocol for transfers by default."
* OpenBSD says "Since OpenSSH 9.0, scp has used the SFTP protocol for transfers by default."

So it seems reasonable to me to set TARGET_VERSION="OpenSSH_8.8" in the installation script.
